### PR TITLE
MapSceneを某タワーディフェンスゲームを参考に更新

### DIFF
--- a/.github/workflows/unittest_action.yml
+++ b/.github/workflows/unittest_action.yml
@@ -21,4 +21,4 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest tests

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ draw_human:
 
 # テスト実行
 test:
-	poetry run pytest
+	poetry run pytest tests
 
 # その他
 zikken:

--- a/src/resources/maptrees/map_tree.py
+++ b/src/resources/maptrees/map_tree.py
@@ -1,0 +1,74 @@
+from resources.maptrees.map_tree_node import MapTreeNode
+
+class MapTree:
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def __getitem__(self, id):
+        nodes = [node for node in self.nodes if node.id == id]
+        return nodes[0] if len(nodes) > 0 else id
+
+    def get_nearest_upper_sibling_node_id(self, id):
+        """最も近い上側の兄弟要素を取得する."""
+        # 兄弟要素を抽出
+        sibling_nodes = self.__filter_siblings(self.nodes, id)
+        # よりyが小さい(上方向)にある要素を抽出
+        upper_sibling_nodes = [node for node in sibling_nodes if node.y <= self.nodes[id].y]
+        if len(upper_sibling_nodes) < 1:
+            return id
+        # yが最も近い要素のIDを取得
+        nearest_upper_sibling_node = self.__find_node_nearest_y(upper_sibling_nodes, id)
+        return nearest_upper_sibling_node.id
+
+    def get_nearest_lowwer_sibling_node_id(self, id):
+        """最も近い下側の兄弟要素を取得する."""
+        # 兄弟要素を抽出
+        sibling_nodes = self.__filter_siblings(self.nodes, id)
+        # よりyが大きい(下方向)にある要素を抽出
+        lowwer_sibling_nodes = [node for node in sibling_nodes if node.y >= self.nodes[id].y]
+        if len(lowwer_sibling_nodes) < 1:
+            return id
+        # yが最も近い要素のIDを取得
+        nearest_lowwer_sibling_node = self.__find_node_nearest_y(lowwer_sibling_nodes, id)
+        return nearest_lowwer_sibling_node.id
+
+    def get_nearest_child_node_id(self, id):
+        """最も近い子要素を取得する."""
+        child_nodes = self.__filter_children(self.nodes, id)
+        if len(child_nodes) < 1:
+            return id
+        nearest_child_node = self.__find_node_nearest_y(child_nodes, id)
+        return nearest_child_node.id
+
+    def get_nearest_parent_node_id(self, id):
+        """最も近い親要素を取得する."""
+        parent_nodes = self.__filter_parents(self.nodes, id)
+        if len(parent_nodes) < 1:
+            return id
+        nearest_parent_node = self.__find_node_nearest_y(parent_nodes, id)
+        return nearest_parent_node.id
+
+    def __filter_parents(self, nodes, id):
+        """指定されたIDの親要素を抽出する."""
+        parent_nodes = [node for node in nodes if id in node.children_ids]
+        return parent_nodes
+
+    def __filter_children(self, nodes, id):
+        """指定されたIDの子要素を抽出する."""
+        child_nodes = [self.nodes[child_id] for child_id in nodes[id].children_ids]
+        return child_nodes
+
+    def __filter_siblings(self, nodes, id):
+        """指定されたIDの要素と同じ親を持つ要素を抽出する."""
+        parent_nodes = self.__filter_parents(nodes, id)
+        sibling_nodes = [sibling_node for parent_node in parent_nodes for sibling_node in self.__filter_children(self.nodes, parent_node.id) if sibling_node.id != id]
+        return sibling_nodes
+
+    def __find_node_nearest_y(self, nodes, id):
+        """指定された要素と最もyが近い要素を1つ返す."""
+        # 指定されたyとの差で受け取った要素をソート
+        sorted_nodes_by_y_diff = sorted(nodes, key=lambda node: abs(self.nodes[id].y - node.y))
+        if len(sorted_nodes_by_y_diff) < 1:
+            return self.nodes[id]
+        nearest_node = sorted_nodes_by_y_diff[0]
+        return nearest_node

--- a/src/resources/maptrees/map_tree.py
+++ b/src/resources/maptrees/map_tree.py
@@ -12,7 +12,7 @@ class MapTree:
         """最も近い上側の兄弟要素を取得する."""
         # 兄弟要素を抽出
         sibling_nodes = self.__filter_siblings(self.nodes, id)
-        # よりyが小さい(上方向)にある要素を抽出
+        # よりyが小さい(上方向にある)要素を抽出
         upper_sibling_nodes = [node for node in sibling_nodes if node.y <= self.nodes[id].y]
         if len(upper_sibling_nodes) < 1:
             return id
@@ -24,7 +24,7 @@ class MapTree:
         """最も近い下側の兄弟要素を取得する."""
         # 兄弟要素を抽出
         sibling_nodes = self.__filter_siblings(self.nodes, id)
-        # よりyが大きい(下方向)にある要素を抽出
+        # よりyが大きい(下方向にある)要素を抽出
         lowwer_sibling_nodes = [node for node in sibling_nodes if node.y >= self.nodes[id].y]
         if len(lowwer_sibling_nodes) < 1:
             return id

--- a/src/resources/maptrees/map_tree.py
+++ b/src/resources/maptrees/map_tree.py
@@ -1,5 +1,3 @@
-from resources.maptrees.map_tree_node import MapTreeNode
-
 class MapTree:
     def __init__(self, nodes):
         self.nodes = nodes

--- a/src/resources/maptrees/map_tree_node.py
+++ b/src/resources/maptrees/map_tree_node.py
@@ -1,0 +1,13 @@
+class MapTreeNode:
+    def __init__(self, id, name, x, y, children_ids):
+        self.id = id
+        self.name = name
+        self.x = x
+        self.y = y
+        self.children_ids = children_ids
+        # TODO: 以下、タイルマップと要調整
+        self.tail_map_id = 0
+        self.tail_left = 0
+        self.tail_top = 0
+        self.tail_width = 8
+        self.tail_height = 8

--- a/src/resources/maptrees/sample_map_tree.py
+++ b/src/resources/maptrees/sample_map_tree.py
@@ -1,7 +1,9 @@
 from resources.maptrees.map_tree import MapTree
 from resources.maptrees.map_tree_node import MapTreeNode
 
+# サンプル用のマップの定義
 sample_map_tree = MapTree([
+    # ノードID, ステージ名, x, y, 遷移可能なノードのID
     MapTreeNode(0, "1-1", 5, 12, [1]),
     MapTreeNode(1, "1-2", 10, 12, [2,3]),
     MapTreeNode(2, "A1-3", 15, 7, [4]),

--- a/src/resources/maptrees/sample_map_tree.py
+++ b/src/resources/maptrees/sample_map_tree.py
@@ -1,0 +1,21 @@
+from resources.maptrees.map_tree import MapTree
+from resources.maptrees.map_tree_node import MapTreeNode
+
+sample_map_tree = MapTree([
+    MapTreeNode(0, "1-1", 5, 12, [1]),
+    MapTreeNode(1, "1-2", 10, 12, [2,3]),
+    MapTreeNode(2, "A1-3", 15, 7, [4]),
+    MapTreeNode(3, "B1-3", 15, 17, [4]),
+    MapTreeNode(4, "1-4", 20, 12, [5,6,7]),
+    MapTreeNode(5, "A1-5", 25, 7, []),
+    MapTreeNode(6, "B1-5", 25, 12, [8]),
+    MapTreeNode(7, "C1-5", 30, 17, []),
+    MapTreeNode(8, "B1-6", 30, 12, [9, 10]),
+    MapTreeNode(9, "BA1-7", 35, 6, [11]),
+    MapTreeNode(10, "BB1-7", 35, 12, [12]),
+    MapTreeNode(11, "BA1-8", 40, 12, [13]),
+    MapTreeNode(12, "BB1-8", 37, 18, [14]),
+    MapTreeNode(13, "B1-9", 45, 12, [15]),
+    MapTreeNode(14, "B1-9", 43, 18, [15]),
+    MapTreeNode(15, "B1-9", 50, 17, []),
+])

--- a/src/scenes/map_scene.py
+++ b/src/scenes/map_scene.py
@@ -1,8 +1,13 @@
 import pyxel
 if __name__ == "__main__":  # noqa
     from path_option import *
+from user_interface.tile_map import TileMap
 from user_interface.image_manager import ImageManager
 from scenes.scene import Scene
+from game_option import Option as Op
+from user_interface.draw_human import DrawHuman
+from resources.maptrees.map_tree import MapTree
+from resources.maptrees.sample_map_tree import sample_map_tree
 
 
 class MapScene(Scene):
@@ -10,7 +15,9 @@ class MapScene(Scene):
         super().__init__()
 
         # 画像関連
-        ImageManager.set_img_background("story_240_180.png")
+        TileMap.set_map("sample.pyxres")
+        self.human = DrawHuman(1)
+        self.human.look_down()  # 下向きに固定
 
         # 実行しているシーンを見極めるための変数
         self.execute_scene_name = "MapScene"
@@ -18,11 +25,29 @@ class MapScene(Scene):
         # テキストボックスフラグ
         self.text_box_flag = False
 
+        # マップ情報
+        self.map_tree = sample_map_tree
+        self.current_map_node_id = 0
+
     def update(self):
         """ゲームの状態を更新する."""
         # 決定ボタン(SPACE)
         if pyxel.btnp(pyxel.KEY_SPACE):  # pyxel.KEY_ENTERは使えない
             self.text_box_flag = not self.text_box_flag
+        # 矢印キー
+        if pyxel.btnr(pyxel.KEY_UP):
+            # 同じ親要素を持つ中で、現在のノードより上の中で、一番yが近いノードのIDを取得する
+            self.current_map_node_id = self.map_tree.get_nearest_upper_sibling_node_id(self.current_map_node_id)
+        elif pyxel.btnr(pyxel.KEY_RIGHT):
+            # 子要素の中で、一番yが近いノードのIDを取得する
+            self.current_map_node_id = self.map_tree.get_nearest_child_node_id(self.current_map_node_id)
+        elif pyxel.btnr(pyxel.KEY_DOWN):
+            # 同じ親要素を持つ中で、現在のノードより下の中で、一番yが近いノードのIDを取得する
+            self.current_map_node_id = self.map_tree.get_nearest_lowwer_sibling_node_id(self.current_map_node_id)
+        elif pyxel.btnr(pyxel.KEY_LEFT):
+            # 親要素の中で、一番yが近いノードのIDを取得する
+            self.current_map_node_id = self.map_tree.get_nearest_parent_node_id(self.current_map_node_id)
+
 
     def draw(self):
         """描画を行う関数.
@@ -30,11 +55,43 @@ class MapScene(Scene):
         pyxel.blt(描画位置x, 描画位置y, 画像ID,
                   描画元画像x, 描画元画像y, 描画幅, 描画高さ, 色)
         """
-        # pyxel.cls(0)  # 画面クリア
-        pyxel.blt(0, 0, ImageManager.background_index(),
-                  0, 0, pyxel.width, pyxel.height)  # 背景
+        pyxel.cls(0)  # 画面クリア
+
+        # 背景
+        pyxel.bltm(0, 0, 0, 0, 0, Op.window_w, Op.window_h)
+        
+        # マップ情報
+        tail_length_w = Op.window_w // 32  # TODO: タイルマップの構造にそろえる
+        tail_length_h = Op.window_h // 24  # TODO: タイルマップの構造にそろえる
+
+        # ステージの表示
+        for node in self.map_tree.nodes:
+            # マップの道
+            for child_id in node.children_ids:
+                child_node = self.map_tree.nodes[child_id]
+                pyxel.line(node.x * tail_length_w, node.y * tail_length_h,
+                           child_node.x * tail_length_w, child_node.y * tail_length_h,
+                           9)
+            pyxel.blt(node.x * tail_length_w,
+                      node.y * tail_length_h,
+                      node.tail_map_id,
+                      node.tail_left, node.tail_top,
+                      node.tail_width, node.tail_height)
+
+        # キャラクター
+        pyxel.bltm(self.map_tree[self.current_map_node_id].x * tail_length_w,
+                   self.map_tree[self.current_map_node_id].y * tail_length_h,
+                   0,
+                   self.human.get_tile_x, self.human.get_tile_y,
+                   16, 16, 0)
+
+        # テキストボックス
         if self.text_box_flag:
+            self.message.text = self.map_tree[self.current_map_node_id].name + "\nhogehogehogehogehogehogehogehogehogehogehogehogehogehogehogehogehogehoge"
             self.message.show_text_box()
+
+        # カメラ移動
+        pyxel.camera(max(0, self.map_tree[self.current_map_node_id].x * tail_length_w - Op.window_w/2), 0)
 
     def next_scene(self):
         """次のシーンを返すメソッド."""

--- a/src/scenes/map_scene.py
+++ b/src/scenes/map_scene.py
@@ -2,11 +2,9 @@ import pyxel
 if __name__ == "__main__":  # noqa
     from path_option import *
 from user_interface.tile_map import TileMap
-from user_interface.image_manager import ImageManager
 from scenes.scene import Scene
 from game_option import Option as Op
 from user_interface.draw_human import DrawHuman
-from resources.maptrees.map_tree import MapTree
 from resources.maptrees.sample_map_tree import sample_map_tree
 
 

--- a/src/user_interface/message.py
+++ b/src/user_interface/message.py
@@ -5,6 +5,7 @@ from user_interface.image_manager import ImageManager  # noqa
 class Message:
     def __init__(self):
         ImageManager.set_img_text_box("text_box_240_48.png")
+        self.text = ""
 
     def show_text_box(self):
         """テキストボックスの表示.
@@ -13,3 +14,4 @@ class Message:
         """
         pyxel.blt(0, pyxel.height-48, ImageManager.text_box_index(),
                   0, 0, pyxel.width, 48)
+        pyxel.text(3, pyxel.height-48+3, self.text, 7)

--- a/tests/test_sample_test.py
+++ b/tests/test_sample_test.py
@@ -1,12 +1,4 @@
 import pytest
-from src.test_sample import TestSample
 
-def test_abs_sum():
-    result = TestSample.abs_sum(1,2)
-    assert result == 3
-    result = TestSample.abs_sum(1,-2)
-    assert result == 3
-    result = TestSample.abs_sum(-1,2)
-    assert result == 3
-    result = TestSample.abs_sum(-1,-2)
-    assert result == 3
+def test_exec_pytest():
+    assert True


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
MapSceneについて、以下を変更
- マップ情報を保持するMapTreeクラスとそれを構成するMapTreeNodeクラスを追加
- 移動方法を変更
  - 左右移動で進む/戻る
  - 上下移動で1つ前のステージに分岐があった場合、他方の分岐に移動できる
- 移動時にカメラを移動する処理を追加(してみた)
- Spaceキーを押した際に表示するメッセージボックスに、現在のステージ名を表示する処理を追加(デモ用)

Messageについて、以下を変更
- textプロパティを追加
- show_text_box()が呼ばれた際に、textプロパティに設定した文字列を表示する処理を追加

# 動作テスト
- マップの移動ができることは確認できた
- カメラを移動した際に、メッセージボックスが左に残されたままとなったため、カメラの座標を上位で管理するか、全体の構造として、UIとマップを明確に切り分けるか、カメラ移動するのであれば何かしらの対応が必要


https://github.com/MiyaKawa25/new_game/assets/83441177/1acee56e-f91a-4928-8797-2eab5f332a07


